### PR TITLE
Github: Run `composer install --no-dev` with various PHP versions

### DIFF
--- a/.github/workflows/test-composer-install.yaml
+++ b/.github/workflows/test-composer-install.yaml
@@ -1,0 +1,48 @@
+name: Test Installation With Different PHP Versions
+
+on: [push]
+
+jobs:
+  run-composer-install:
+    name: Run Composer Install
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+
+    steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "${{ matrix.php-version }}"
+        extensions: json, xdebug
+        tools: composer:v2
+
+    - name: Check Out Code
+      uses: actions/checkout@v2
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Connect Downloaded Dependencies With A Cache In GitHub
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        # Note: Normally, we'd use the composer.lock to generate a hash,
+        # but the lock file is currently not versioned.
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install Production Dependencies
+      run: composer install --no-dev --prefer-dist


### PR DESCRIPTION
Clockwork currently supports 7.1 - 8.4, so it should better work with them.