### PR TITLE
Demonstrate integration of PHPStan and GitHub

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -50,6 +50,10 @@ jobs:
       continue-on-error: true
       run: vendor/bin/phpstan analyze --error-format=sarif > phpstan-results.sarif
 
+    - name: Show PHPStan Results
+      continue-on-error: true
+      run: cat phpstan-results.sarif
+
     - name: Upload analysis results to GitHub
       uses: github/codeql-action/upload-sarif@v3
       with:

--- a/Clockwork/Clockwork.php
+++ b/Clockwork/Clockwork.php
@@ -48,6 +48,11 @@ class Clockwork
 		return $this;
 	}
 
+	public function demo(): Clockwork
+	{
+		return null;
+	}
+
 	// Resolve the current request, sending it through all data sources, finalizing log and timeline
 	public function resolveRequest()
 	{


### PR DESCRIPTION
This merge request demonstrates the integration of PHPStan as static analyzer into GitHub's infrastructure. For that, it intentionally creates a bit of flawed code (mismatch between annotated and actual return type), which the analyzer catches and embeds as comment into the PR.
