### PR TITLE
Integration of PHPStan and GitHub

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -1,0 +1,57 @@
+name: PHPStan Static Analyzer
+on:
+  push:
+    branches:
+    - master
+    - v1
+    - v2
+    - v3
+    - v4
+    - v5
+  pull_request:
+jobs:
+  run-phpstan:
+    name: Run PHPStan
+    runs-on: ubuntu-latest
+    permissions:
+      # for github/codeql-action/upload-sarif to upload SARIF results
+      security-events: write
+    steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        extensions: json, xdebug
+        tools: composer:v2
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Get Composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Connect downloaded dependencies with a cache in GitHub
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        # Note: Normally, we'd use the composer.lock to generate a hash,
+        # but the lock file is currently not versioned.
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist
+
+    - name: Audit dependencies
+      run: composer audit
+
+    - name: Run PHPStan
+      continue-on-error: true
+      run: vendor/bin/phpstan analyze --error-format=sarif > phpstan-results.sarif
+
+    - name: Upload analysis results to GitHub
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: phpstan-results.sarif
+        wait-for-processing: true

--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ clock()->event('Updating cache', [ 'color' => 'green' ])->run(function () {
 
 Read more about available features on the [Clockwork website](https://underground.works/clockwork).
 
+## Hacking
+
+### PHPStan Static Analyzer
+
+#### GitHub Integration
+
+All code is checked for common flaws using [PHPStan](https://phpstan.org),
+a static code analyzer. This is automatically executed in a GitHub action
+defined in [phpstan.yaml](.github/workflows/phpstan.yaml). The results are
+automatically uploaded to [GitHub QL](https://codeql.github.com) to make
+them available in pull requests.
+
+#### Running PHPStan Locally
+
+You can execute PHPStan using `vendor/bin/phpstan analyze`, but this will
+turn up a bunch of existing and known flaws, much more than in a PR in
+GitHub, so this is of limited use. Also, the exact output depends on the
+version of PHP, installed extensions and other packages you may have
+installed locally.
+
 <p align="center">
 	<a href="https://underground.works">
 		<img width="150px" src="https://github.com/itsgoingd/clockwork/raw/master/.github/assets/footer.png">

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,16 @@
                 "Clockwork": "Clockwork\\Support\\Laravel\\Facade"
             }
         }
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.10",
+        "spaze/phpstan-disallowed-calls": "^3.0",
+        "phpstan/extension-installer": "^1.3",
+        "jbelien/phpstan-sarif-formatter": "^1.2"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,28 @@
+parameters:
+	level: 9
+	excludePaths:
+		# Exclude a few source files because they require additional packages
+		# that are not direct dependencies.
+		# TODO: At least install them as dev-dependencies or even just in the
+		# Github pipeline.
+		- Clockwork/DataSource/DBALDataSource.php
+		- Clockwork/DataSource/DoctrineDataSource.php
+		- Clockwork/DataSource/EloquentDataSource.php
+		- Clockwork/DataSource/GuzzleDataSource.php
+		- Clockwork/DataSource/Laravel*DataSource.php
+		- Clockwork/DataSource/LumenDataSource.php
+		- Clockwork/DataSource/MonologDataSource.php
+		- Clockwork/DataSource/SlimDataSource.php
+		- Clockwork/DataSource/SwiftDataSource.php
+		- Clockwork/DataSource/TwigDataSource.php
+		- Clockwork/Support
+	paths:
+		- Clockwork
+
+services:
+	errorFormatter.sarif:
+		class: PHPStanSarifErrorFormatter\SarifErrorFormatter
+		arguments:
+			relativePathHelper: @simpleRelativePathHelper
+			currentWorkingDirectory: %currentWorkingDirectory%
+			pretty: true


### PR DESCRIPTION
This integrates PHPStan into the workflow. PHPStan is executed as part of the GitHub Actions and the results for pull requests are automatically attached as comments.
